### PR TITLE
Update gemspec dependency versions

### DIFF
--- a/puppet-lint-vim_modeline-check.gemspec
+++ b/puppet-lint-vim_modeline-check.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-vim_modeline-check'
-  spec.version     = '0.1.0'
+  spec.version     = '0.1.1'
   spec.homepage    = 'https://github.com/robertpearce/puppet-lint-vim_modeline-check'
   spec.license     = 'MIT'
   spec.author      = 'Robert Pearce'
@@ -16,26 +16,12 @@ Gem::Specification.new do |spec|
   spec.description = <<-EOF
     A puppet-lint plugin to check that manifest files end with a vim modeline as the last line.
   EOF
- 
-  spec.add_dependency             'puppet-lint', '~> 2.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rspec-its', '~> 1.0'
-  spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
 
-  if RUBY_VERSION < '2.0'
-      # json 2.x requires ruby 2.0. Lock to 1.8
-      spec.add_development_dependency 'json', '= 1.8'
-      # json_pure 2.0.2 requires ruby 2.0, and 2.0.1 requires ruby 1.9. Lock to 1.8.3.
-      spec.add_development_dependency 'json_pure', '= 1.8.3'
-      # addressable 2.4.0 requires ruby 1.9.0. Lock to 2.3.8.
-      spec.add_development_dependency 'addressable', '= 2.3.8'
-  else
-      spec.add_development_dependency 'json'
-  end
-
-  if RUBY_VERSION > '1.8'
-      # requires ruby 1.9+, on 1.8 we'll fall back to the old regex parsing
-      spec.add_development_dependency 'rspec-json_expectations', '~> 1.4'
-  end
+  spec.add_dependency             'puppet-lint'
+  spec.add_development_dependency 'rspec'
+  spec.add_development_dependency 'rspec-its'
+  spec.add_development_dependency 'rspec-collection_matchers'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'json'
+  spec.add_development_dependency 'rspec-json_expectations'
 end


### PR DESCRIPTION
This simplifies the file since we are running Ruby 2.1.9 and Puppet 5 is moving to Ruby 2.4